### PR TITLE
Makefile: Backup-Target für PostgreSQL-Dumps hinzufügen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.Zone.Identifier
 .phpunit.result.cache
 tests/e2e/screenshots/
+/backups/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: up down build composer-install migrate seed test test-unit test-integration test-e2e test-e2e-visible analyse fresh
+.PHONY: up down build composer-install migrate seed backup test test-unit test-integration test-e2e test-e2e-visible analyse fresh
+
+BACKUP_DATE := $(shell date +%y-%m-%d)
+BACKUP_DIR := backups
+BACKUP_FILE := $(BACKUP_DIR)/backup-$(BACKUP_DATE).sql
 
 up:
 	docker compose up -d
@@ -17,6 +21,11 @@ migrate:
 
 seed:
 	docker compose exec -e APP_ENV=dev app php bin/console doctrine:fixtures:load --no-interaction
+
+backup:
+	@mkdir -p $(BACKUP_DIR)
+	docker compose exec -T db sh -c 'PGPASSWORD="$$POSTGRES_PASSWORD" pg_dump -U "$$POSTGRES_USER" "$$POSTGRES_DB"' > $(BACKUP_FILE)
+	@echo "Backup written to $(BACKUP_FILE)"
 
 test:
 	docker compose exec app php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Single-Page-App zur Steuerung von Teams, Initiativen und Merkliste ("Nicht verge
 # PHP-Backend (Symfony)
 composer install
 make up              # Docker Compose
+make backup          # PostgreSQL-Dump nach backups/backup-yy-mm-dd.sql schreiben
 
 # JavaScript-Tooling (Entwicklung)
 npm install


### PR DESCRIPTION
### Motivation
- Einfaches, reproducible Backup der PostgreSQL-Datenbank vom `db`-Docker-Service auf den Host bereitstellen und generierte Dumps nicht ins Repository bringen.

### Description
- Ergänzt `Makefile` um `BACKUP_DATE`, `BACKUP_DIR` und `BACKUP_FILE` Variablen und ein `backup`-Target, das `backups/backup-yy-mm-dd.sql` erzeugt und den Dump mit `pg_dump` aus dem `db`-Container schreibt.
- Das `backup`-Target nutzt `docker compose exec -T db sh -c 'PGPASSWORD="$$POSTGRES_PASSWORD" pg_dump -U "$$POSTGRES_USER" "$$POSTGRES_DB"' > $(BACKUP_FILE)` und gibt den Pfad aus.
- `README.md` wurde um einen Hinweis auf `make backup` ergänzt, der das Zielverzeichnis und Namensschema dokumentiert.
- `.gitignore` erweitert, um das Verzeichnis `/backups/` auszuschließen.

### Testing
- `make -n backup` (Dry-run) wurde ausgeführt und zeigte die erwarteten Befehle, daher erfolgreich.
- Versuch `docker compose up -d db` zur Validierung wurde automatisch ausgeführt, schlug jedoch fehl, weil `docker` in dieser Umgebung nicht installiert ist (fehlgeschlagen).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1877bf9288331965a429d7fb631cf)